### PR TITLE
Minor fixes to mimic the JSON that the ruby server posts.

### DIFF
--- a/lib/cloudq.coffee
+++ b/lib/cloudq.coffee
@@ -7,7 +7,7 @@ class Cloudq
   EMPTY: 'empty'
   SUCCESS: 'success'
 
-  constructor: (db = 'localhost:27017/cloudq', collection_name = 'jobs') ->
+  constructor: (db = 'localhost:27017/cloudq', collection_name = 'cloudq.jobs') ->
     # Init MongoDb
     @db = mongo.db(db)
     @jobs = @db.collection(collection_name)
@@ -23,7 +23,7 @@ class Cloudq
       if job
         job.workflow_state = @RESERVED
         @jobs.updateById job._id, job
-        result = { job: job }
+        result = job
       callback result
 
   remove: (id, callback) ->


### PR DESCRIPTION
DB fixed to be the same database (cloudq.cloudq.jobs instead of cloudq.jobs) that the ruby server posts to. Hash fixed to not include the {job:} prefix. Mimics cloudq_client.

Remove seems to duplicate the items for some reason.
